### PR TITLE
feat: add second preview bucket to sam template

### DIFF
--- a/infrastructure/page/page-madamot-live-cache/template.yaml
+++ b/infrastructure/page/page-madamot-live-cache/template.yaml
@@ -11,6 +11,13 @@ Resources:
     Properties:
       BucketName: page-madamot-live-cache
 
+  PreviewSourceBucket:
+    Type: AWS::S3::Bucket
+    DependsOn:
+      - SNSTopicPolicy
+    Properties:
+      BucketName: page-madamot-live-preview-cache
+
   SNSTopic:
     Type: AWS::SNS::Topic
     Properties:
@@ -32,6 +39,7 @@ Resources:
             Condition:
               ArnEquals:
                 aws:SourceArn: !Join ['', ['arn:aws:s3:::', page-madamot-live-cache]]
+                aws:SourceArn: !Join ['', ['arn:aws:s3:::', page-madamot-live-preview-cache]]
               StringEquals:
                 aws:SourceAccount: !Ref 'AWS::AccountId'
       Topics:
@@ -52,7 +60,7 @@ Outputs:
       Name: SNSTopicArn
     Value: !Ref SNSTopic
   SNSTopicName:
-    Description: The arn of the page-deploy-site sns topic
+    Description: The name of the page-deploy-site sns topic
     Export:
       Name: SNSTopicName
     Value: !GetAtt SNSTopic.TopicName

--- a/infrastructure/page/page-madamot-live/template.yaml
+++ b/infrastructure/page/page-madamot-live/template.yaml
@@ -16,3 +16,16 @@ Resources:
       WebsiteConfiguration:
         IndexDocument: index.html
         ErrorDocument: 404.html
+
+  PreviewSourceBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: page-madamot-live-preview
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: false
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: ObjectWriter
+      WebsiteConfiguration:
+        IndexDocument: index.html
+        ErrorDocument: 404.html

--- a/lambdas/page-cache/src/utils/fetch.ts
+++ b/lambdas/page-cache/src/utils/fetch.ts
@@ -2,18 +2,19 @@ const axios = require('axios')
 const cmsKey = require('./cmsKey')
 const queries = require('../graphql/queries')
 
-export const page = async (id?: number) => {
+export const getPageData = async (preview: boolean, id?: number) => {
   const key = await cmsKey.get()
-  const pageData = await graphqlRequest(key, id)
+  const pageData = await graphqlRequest(preview, key, id)
 
   return pageData
 }
 
-const graphqlRequest = async (key: string, id?: number) => {
+const graphqlRequest = async (preview: boolean, key: string, id?: number) => {
   const endpoint = 'https://graphql.datocms.com'
   const headers = {
     'content-type': 'application/json',
     Authorization: `Bearer ${key}`,
+    ...(preview && { 'X-Include-Drafts': true }),
   }
 
   let graphqlQuery

--- a/lambdas/page-cache/template.yaml
+++ b/lambdas/page-cache/template.yaml
@@ -19,6 +19,8 @@ Resources:
       Policies:
         - S3FullAccessPolicy:
             BucketName: page-madamot-live-cache # bucket name without arn
+        - S3FullAccessPolicy:
+            BucketName: page-madamot-live-preview-cache
         - SNSPublishMessagePolicy:
             TopicName: !ImportValue SNSTopicName
         - AWSSecretsManagerGetSecretValuePolicy:

--- a/lambdas/page-deploy-site/src/utils/cache.ts
+++ b/lambdas/page-deploy-site/src/utils/cache.ts
@@ -2,12 +2,15 @@ import { HomepageRecord, ProjectRecord } from '../generated/graphql'
 import { getFile } from './s3'
 
 export const getCache = async (
-  page: string
+  page: string,
+  isPreview: boolean
 ): Promise<ProjectRecord | HomepageRecord | undefined> => {
-  console.log('About to get: ', page)
+  const bucket = isPreview ? 'page-madamot-live-preview-cache' : 'page-madamot-live-cache'
+
+  console.log(`About to get page ${page} from bucket ${bucket}`)
 
   try {
-    const pageContents = await getFile('page-madamot-live-cache', page)
+    const pageContents = await getFile(bucket, page)
     return JSON.parse(pageContents ?? '')
   } catch (error) {
     console.error("The page doesn't exist in the cache", error)

--- a/lambdas/page-deploy-site/src/utils/savePage.ts
+++ b/lambdas/page-deploy-site/src/utils/savePage.ts
@@ -1,13 +1,19 @@
 import { putFile } from './s3'
 
-export const savePage = async (cache: any, page: File) => {
-  const key = destinationPath(cache)
+export const savePage = async (isPreview: boolean, cache: any, page: File) => {
+  const key = destinationPath(cache, isPreview)
+  const bucket = isPreview ? 'page-madamot-live-preview' : 'page-madamot-live'
 
-  console.log('Saving file: ' + key)
+  console.log(`Saving file to bucket ${bucket}`)
 
-  return putFile('page-madamot-live', key, page, 'text/html')
+  return putFile(bucket, key, page, 'text/html')
 }
 
-const destinationPath = (cache: any) => {
-  return cache.project.location + (cache.project.location ? '/' : '') + 'index.html'
+const destinationPath = (cache: any, isPreview: boolean) => {
+  return (
+    (isPreview ? 'preview/' : '') +
+    cache.project.location +
+    (cache.project.location ? '/' : '') +
+    'index.html'
+  )
 }

--- a/lambdas/page-deploy-site/template.yaml
+++ b/lambdas/page-deploy-site/template.yaml
@@ -21,6 +21,10 @@ Resources:
             BucketName: page-madamot-live # bucket name without arn
         - S3FullAccessPolicy:
             BucketName: page-madamot-live-cache # bucket name without arn
+        - S3FullAccessPolicy:
+            BucketName: page-madamot-live-preview
+        - S3FullAccessPolicy:
+            BucketName: page-madamot-live-preview-cache
         - AWSSecretsManagerGetSecretValuePolicy:
             SecretArn: 'arn:aws:secretsmanager:eu-west-1:745413044589:secret:DatoCMS/page-deploy-site/API_KEY-uNpJBp'
         - Statement:


### PR DESCRIPTION
add second preview cache bucket to sam template

allow preview cache bucket to publish messages to sns topic

give permission to page-cache lambda to access preview cache bucket

give permission to page-deploy-site lambda to get from preview and cache preview buckets

page-cache depending on payload event type change buckets

page-cache if save payload allow gql query to get drafts

page-deploy-site change bucket for get cache and save depending on payload type